### PR TITLE
Remove node 8 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ before_script:
 - npm install
 jobs:
   include:
-  - node_js: 8
-    script:
-    - npm run test
   - node_js: 10
     script:
     - npm run test


### PR DESCRIPTION
Some libraries don't support Node 8 anymore unless you use old and insecure versions. Dependabot cannot automatically update this since Travis execution fails

Fix: Remove it from travis config